### PR TITLE
Update dependencies to use NPM for @astropub/md

### DIFF
--- a/packages/starlight-openapi/package.json
+++ b/packages/starlight-openapi/package.json
@@ -15,6 +15,7 @@
     "lint": "prettier -c --cache . && eslint . --cache --max-warnings=0"
   },
   "dependencies": {
+    "@astropub/md": "^0.3.0",
     "@readme/openapi-parser": "2.5.0",
     "github-slugger": "2.0.0",
     "kleur": "4.1.5"

--- a/packages/starlight-openapi/package.json
+++ b/packages/starlight-openapi/package.json
@@ -15,7 +15,6 @@
     "lint": "prettier -c --cache . && eslint . --cache --max-warnings=0"
   },
   "dependencies": {
-    "@astropub/md": "https://gitpkg.now.sh/astro-community/md/packages/md?124d0f2f4301836d94dfcd5ae77c8f03bbb20c1c",
     "@readme/openapi-parser": "2.5.0",
     "github-slugger": "2.0.0",
     "kleur": "4.1.5"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -62,6 +62,9 @@ importers:
 
   packages/starlight-openapi:
     dependencies:
+      '@astropub/md':
+        specifier: ^0.3.0
+        version: 0.3.0(@astrojs/markdown-remark@3.2.1)
       '@readme/openapi-parser':
         specifier: 2.5.0
         version: 2.5.0(openapi-types@12.1.3)
@@ -218,6 +221,14 @@ packages:
       which-pm-runs: 1.1.0
     transitivePeerDependencies:
       - supports-color
+
+  /@astropub/md@0.3.0(@astrojs/markdown-remark@3.2.1):
+    resolution: {integrity: sha512-cR4gT97/aI9GH26Hg4g5tZZl5MFeEH26RO54irjiTK7FEmILbGViHAXI+q+7VCghi1bEGsy5SpY3u1hRoAFNfQ==}
+    peerDependencies:
+      '@astrojs/markdown-remark': ^3
+    dependencies:
+      '@astrojs/markdown-remark': 3.2.1(astro@3.2.3)
+    dev: false
 
   /@babel/code-frame@7.22.13:
     resolution: {integrity: sha512-XktuhWlJ5g+3TJXc5upd9Ks1HutSArik6jf2eAjYFyIOf4ej3RN+184cZbzDvbPnuTJIUhPKKJE3cIsYTiAT3w==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -62,9 +62,6 @@ importers:
 
   packages/starlight-openapi:
     dependencies:
-      '@astropub/md':
-        specifier: https://gitpkg.now.sh/astro-community/md/packages/md?124d0f2f4301836d94dfcd5ae77c8f03bbb20c1c
-        version: '@gitpkg.now.sh/astro-community/md/packages/md?124d0f2f4301836d94dfcd5ae77c8f03bbb20c1c(@astrojs/markdown-remark@3.2.1)'
       '@readme/openapi-parser':
         specifier: 2.5.0
         version: 2.5.0(openapi-types@12.1.3)
@@ -2326,6 +2323,7 @@ packages:
 
   /eslint-config-prettier@9.0.0(eslint@8.49.0):
     resolution: {integrity: sha512-IcJsTkJae2S35pRsRAwoCE+925rJJStOdkKnLVgtE+tEpqU0EVVM7OqrwxqgptKdX29NUwC82I5pXsGFIgSevw==}
+    hasBin: true
     peerDependencies:
       eslint: '>=7.0.0'
     dependencies:
@@ -5690,6 +5688,7 @@ packages:
 
   /update-browserslist-db@1.0.11(browserslist@4.21.10):
     resolution: {integrity: sha512-dCwEFf0/oT85M1fHBg4F0jtLwJrutGoHSQXCh7u4o2t1drG+c0a9Flnqww6XUKSfQMPpJBRjU8d4RXB09qtvaA==}
+    hasBin: true
     peerDependencies:
       browserslist: '>= 4.21.0'
     dependencies:
@@ -5744,6 +5743,7 @@ packages:
   /vite@4.4.9(@types/node@18.17.3):
     resolution: {integrity: sha512-2mbUn2LlUmNASWwSCNSJ/EG2HuSRTnVNaydp6vMCm5VIqJsjMfbIWtbH2kDuwUVW5mMUKKZvGPX/rqeqVvv1XA==}
     engines: {node: ^14.18.0 || >=16.0.0}
+    hasBin: true
     peerDependencies:
       '@types/node': '>= 14'
       less: '*'
@@ -5911,14 +5911,3 @@ packages:
 
   /zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
-
-  '@gitpkg.now.sh/astro-community/md/packages/md?124d0f2f4301836d94dfcd5ae77c8f03bbb20c1c(@astrojs/markdown-remark@3.2.1)':
-    resolution: {tarball: https://gitpkg.now.sh/astro-community/md/packages/md?124d0f2f4301836d94dfcd5ae77c8f03bbb20c1c}
-    id: '@gitpkg.now.sh/astro-community/md/packages/md?124d0f2f4301836d94dfcd5ae77c8f03bbb20c1c'
-    name: '@astropub/md'
-    version: 0.3.0
-    peerDependencies:
-      '@astrojs/markdown-remark': ^3
-    dependencies:
-      '@astrojs/markdown-remark': 3.2.1(astro@3.2.3)
-    dev: false


### PR DESCRIPTION

<!---
Thanks for submitting a pull request 😄 !
Please provide as much details as possible, including screenshots or sample code if necessary.
-->

**Describe the pull request**


**Why**

When installing the package with Yarn, it fails to resolve gitpkg link in the `@astropub/md` dependency. Apparently that's due to Yarn likely not being able to resolve [query params](https://github.com/yarnpkg/berry/issues/2437#issuecomment-1674246288). 

**How**

Looks like the necessary changes are already published in the [NPM version](https://www.npmjs.com/package/@astropub/md/v/0.3.0) of the package, so this small update replaces the gitpkg link with an NPM link.

**Screenshots**

Not applicable

