### PR TITLE
fix: renders Markdown in all `description` fields

### DIFF
--- a/packages/starlight-openapi/components/parameter/Parameter.astro
+++ b/packages/starlight-openapi/components/parameter/Parameter.astro
@@ -5,8 +5,8 @@ import { isParameterWithSchemaObject } from '../../libs/schemaObject'
 import Content from '../Content.astro'
 import Items from '../Items.astro'
 import Key from '../Key.astro'
+import Md from '../Md.astro'
 import Schema from '../schema/Schema.astro'
-import Text from '../Text.astro'
 
 interface Props {
   parameter: Parameter
@@ -20,12 +20,12 @@ const { parameter } = Astro.props
     isOpenAPIV2Items(parameter) ? (
       <>
         <Items items={parameter} />
-        <Text>{parameter.description}</Text>
+        <Md text={parameter.description} />
       </>
     ) : parameter.content ? (
       <>
         <Content content={parameter.content} />
-        <Text>{parameter.description}</Text>
+        <Md text={parameter.description} />
       </>
     ) : isParameterWithSchemaObject(parameter) ? (
       <Schema

--- a/packages/starlight-openapi/components/schema/Schema.astro
+++ b/packages/starlight-openapi/components/schema/Schema.astro
@@ -1,7 +1,7 @@
 ---
 import { isSchemaObjectObject, type SchemaObject as SchemaObjectType } from '../../libs/schemaObject'
 import Examples, { type Props as ExamplesProps } from '../example/Examples.astro'
-import Text from '../Text.astro'
+import Md from '../Md.astro'
 
 import SchemaObject from './SchemaObject.astro'
 
@@ -16,7 +16,7 @@ const { description, example, examples, schema } = Astro.props
 const isObject = schema && isSchemaObjectObject(schema)
 ---
 
-{isObject && <Text>{description}</Text>}
+{isObject && <Md text={description} />}
 {schema && <SchemaObject schemaObject={schema} hideExample={example !== undefined || examples !== undefined} />}
-{!isObject && <Text>{description}</Text>}
+{!isObject && <Md text={description} />}
 <Examples example={example} examples={examples} />


### PR DESCRIPTION
<!---
Thanks for submitting a pull request 😄 !
Please provide as much details as possible, including screenshots or sample code if necessary.
-->

**Describe the pull request**

Closes #33 

This PR uses the Markdown component to render all description fields in line with the [OpenAPI spec linked in the above issue](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#rich-text-formatting). From my own testing, the component renders Markdown as expected.

**Why**

As mentioned in #33, description fields for parameters may include Markdown just as the schema description field does. To ensure that these fields are rendered properly, the `Md.astro` component should be used in place of the `Text.astro` component.

**How**

The `Text.astro` component has been replaced with the `Md.astro` component for all parameter description fields.

**Screenshots**

<img width="1440" alt="Screenshot 2024-05-28 at 18 08 20" src="https://github.com/HiDeoo/starlight-openapi/assets/29224057/070a11f6-6a9e-47da-82c2-f96dc1d26491">

<!-- Feel free to add additional comments. -->
