### PR TITLE
Fix definitions using `oneOf` or `anyOf` combined with `allOf` keyword

### DIFF
--- a/packages/starlight-openapi/components/schema/SchemaObject.astro
+++ b/packages/starlight-openapi/components/schema/SchemaObject.astro
@@ -43,7 +43,7 @@ const isNegated = schemaObject.not !== undefined
       {isSchemaObjectObject(schemaObject) ? (
         <SchemaObjectObject {parents} {nested} {schemaObject} />
       ) : isSchemaObjectAllOf(schemaObject) ? (
-        <SchemaObjectAllOf {parents} {schemaObject} />
+        <SchemaObjectAllOf {nested} {parents} {schemaObject} />
       ) : (
         <Items {parents} items={schemaObject} {negated} nullable={getNullable(schemaObject)} />
       )}

--- a/packages/starlight-openapi/components/schema/SchemaObjectAllOf.astro
+++ b/packages/starlight-openapi/components/schema/SchemaObjectAllOf.astro
@@ -2,6 +2,7 @@
 import {
   getNullable,
   getProperties,
+  getSchemaObjects,
   isSchemaObject,
   isSchemaObjectObject,
   type SchemaObject,
@@ -9,31 +10,47 @@ import {
 import Items from '../Items.astro'
 
 import SchemaObjectObjectProperties from './SchemaObjectObjectProperties.astro'
+import SchemaObjects from './SchemaObjects.astro'
 
 interface Props {
+  nested: boolean
   parents?: SchemaObject[]
   schemaObject: SchemaObject
 }
 
-const { schemaObject, parents = [] } = Astro.props
+const { nested, schemaObject, parents = [] } = Astro.props
 ---
 
 {
   schemaObject.allOf &&
-    schemaObject.allOf.map((allOfSchemaObject) =>
-      isSchemaObjectObject(schemaObject) && isSchemaObject(allOfSchemaObject) ? (
-        <SchemaObjectObjectProperties
-          parents={[...parents, schemaObject]}
-          properties={getProperties(allOfSchemaObject)}
-          required={allOfSchemaObject.required}
-        />
-      ) : isSchemaObject(allOfSchemaObject) ? (
+    schemaObject.allOf.map((allOfSchemaObject) => {
+      if (!isSchemaObject(allOfSchemaObject)) return null
+      const schemaObjects = getSchemaObjects(allOfSchemaObject)
+      if (schemaObjects !== undefined) {
+        return (
+          <SchemaObjects
+            parents={[...parents, schemaObject]}
+            discriminator={schemaObject.discriminator}
+            {nested}
+            {schemaObjects}
+          />
+        )
+      } else if (isSchemaObjectObject(schemaObject)) {
+        return (
+          <SchemaObjectObjectProperties
+            parents={[...parents, schemaObject]}
+            properties={getProperties(allOfSchemaObject)}
+            required={allOfSchemaObject.required}
+          />
+        )
+      }
+      return (
         <Items
           items={allOfSchemaObject}
           negated={allOfSchemaObject.not !== undefined}
           nullable={getNullable(allOfSchemaObject)}
           parents={[...parents, schemaObject]}
         />
-      ) : null,
-    )
+      )
+    })
 }

--- a/packages/starlight-openapi/components/schema/SchemaObjectObject.astro
+++ b/packages/starlight-openapi/components/schema/SchemaObjectObject.astro
@@ -29,7 +29,7 @@ const properties = getProperties(schemaObject)
     ]}
   />
   <SchemaObjectObjectProperties parents={[...parents, schemaObject]} {properties} required={schemaObject.required} />
-  <SchemaObjectAllOf {parents} {schemaObject} />
+  <SchemaObjectAllOf {nested} {parents} {schemaObject} />
   {
     schemaObject.additionalProperties && (
       <Key additional name="key">

--- a/packages/starlight-openapi/tests/requestBody.test.ts
+++ b/packages/starlight-openapi/tests/requestBody.test.ts
@@ -82,6 +82,20 @@ test('supports schema object `allOf` property for non-objects', async ({ docPage
   await expect(typeParameter.getByText('Allowed values: berkshire tamworth')).toBeVisible()
 })
 
+test('supports schema object `allOf` property with nested schema objects like `anyOf`', async ({ docPage }) => {
+  await docPage.goto('/v3/animals/operations/okapi/')
+
+  const requestBody = docPage.getRequestBody()
+
+  await expect(requestBody.getByText('Any of:')).toBeVisible()
+
+  await expect(requestBody.getByRole('tab')).toContainText(['basic details', 'advanced details'])
+
+  await requestBody.getByRole('tab', { name: 'advanced details' }).click()
+
+  await expect(requestBody.getByText('age')).toBeVisible()
+})
+
 test('supports schema object `oneOf` property', async ({ docPage }) => {
   await docPage.goto('/v2/animals/operations/addbird/')
 

--- a/schemas/v3.0/animals.yaml
+++ b/schemas/v3.0/animals.yaml
@@ -336,6 +336,53 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
+  /okapi:
+    post:
+      summary: Creates a new okapi
+      tags:
+        - animals
+      requestBody:
+        description: Okapi to add
+        required: true
+        content:
+          application/json:
+            schema:
+              allOf:
+                - type: object
+                  properties:
+                    id:
+                      type: integer
+                      format: int64
+                - type: object
+                  properties:
+                    name:
+                      type: string
+                - anyOf:
+                    - type: object
+                      title: 'basic details'
+                      properties:
+                        color:
+                          type: string
+                    - type: object
+                      title: 'advanced details'
+                      properties:
+                        color:
+                          type: string
+                        age:
+                          type: integer
+      responses:
+        '200':
+          description: animal response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Animal'
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
 webhooks:
   newAnimal:
     post:


### PR DESCRIPTION
Closes #52 

```yaml
allOf:
  - type: object
    properties:
      id:
        type: integer
        format: int64
  - type: object
    properties:
      name:
        type: string
  - anyOf:
      - type: object
        title: 'basic details'
        properties:
          color:
            type: string
      - type: object
        title: 'advanced details'
        properties:
          color:
            type: string
          age:
            type: integer
```

<img width="740" alt="image" src="https://github.com/user-attachments/assets/45e10160-cec3-4790-94c5-046644726a24">
