### PR TITLE
fix: Fixes an invalid link for security schemes when using the Astro `base` option

### DIFF
--- a/packages/starlight-openapi/components/security/Security.astro
+++ b/packages/starlight-openapi/components/security/Security.astro
@@ -14,6 +14,7 @@ interface Props {
 const { operation, schema } = Astro.props
 
 const requirements = getSecurityRequirements(schema, operation)
+const baseURL = (import.meta.env.BASE_URL || '').replace(/\/$/, '')
 ---
 
 {
@@ -35,7 +36,7 @@ const requirements = getSecurityRequirements(schema, operation)
             return (
               <li class="scheme not-content">
                 <strong>
-                  <a href={`${getBaseLink(schema.config)}#${slug(scheme)}`}>{scheme}</a>
+                  <a href={`${baseURL}${getBaseLink(schema.config)}#${slug(scheme)}`}>{scheme}</a>
                 </strong>
                 {scopes.length > 0 ? <Tags tags={[...scopes]} /> : null}
               </li>

--- a/packages/starlight-openapi/components/security/Security.astro
+++ b/packages/starlight-openapi/components/security/Security.astro
@@ -14,7 +14,6 @@ interface Props {
 const { operation, schema } = Astro.props
 
 const requirements = getSecurityRequirements(schema, operation)
-const baseURL = (import.meta.env.BASE_URL || '').replace(/\/$/, '')
 ---
 
 {
@@ -36,7 +35,7 @@ const baseURL = (import.meta.env.BASE_URL || '').replace(/\/$/, '')
             return (
               <li class="scheme not-content">
                 <strong>
-                  <a href={`${baseURL}${getBaseLink(schema.config)}#${slug(scheme)}`}>{scheme}</a>
+                  <a href={`${getBaseLink(schema.config)}#${slug(scheme)}`}>{scheme}</a>
                 </strong>
                 {scopes.length > 0 ? <Tags tags={[...scopes]} /> : null}
               </li>

--- a/packages/starlight-openapi/libs/env.d.ts
+++ b/packages/starlight-openapi/libs/env.d.ts
@@ -1,0 +1,7 @@
+interface ImportMetaEnv {
+  readonly BASE_URL: string
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv
+}

--- a/packages/starlight-openapi/libs/path.ts
+++ b/packages/starlight-openapi/libs/path.ts
@@ -4,13 +4,29 @@ import type { StarlightOpenAPISchemaConfig } from './schema'
 
 export { slug } from 'github-slugger'
 
-export function getBaseLink(config: StarlightOpenAPISchemaConfig) {
+const base = stripTrailingSlash(import.meta.env.BASE_URL)
+
+/**
+ * Does not take the Astro `base` configuration option into account.
+ * @see {@link getBaseLink} for a link that does.
+ */
+export function getBasePath(config: StarlightOpenAPISchemaConfig) {
   const path = config.base
     .split('/')
     .map((part) => slug(part))
     .join('/')
 
   return `/${path}/`
+}
+
+/**
+ * Takes the Astro `base` configuration option into account.
+ * @see {@link getBasePath} for a slug that does not.
+ */
+export function getBaseLink(config: StarlightOpenAPISchemaConfig) {
+  const path = stripLeadingSlash(getBasePath(config))
+
+  return path ? `${base}/${path}` : `${base}/`
 }
 
 export function stripLeadingAndTrailingSlashes(path: string): string {

--- a/packages/starlight-openapi/libs/pathItem.ts
+++ b/packages/starlight-openapi/libs/pathItem.ts
@@ -1,10 +1,10 @@
 import { getOperationsByTag, getWebhooksOperations } from './operation'
-import { getBaseLink } from './path'
+import { getBasePath } from './path'
 import type { Schema } from './schema'
 import { makeSidebarGroup, makeSidebarLink, type SidebarManualGroup } from './starlight'
 
 export function getPathItemSidebarGroups({ config, document }: Schema): SidebarManualGroup['items'] {
-  const baseLink = getBaseLink(config)
+  const baseLink = getBasePath(config)
   const operations = getOperationsByTag(document)
 
   return [...operations.entries()].map(([tag, operations]) =>
@@ -17,7 +17,7 @@ export function getPathItemSidebarGroups({ config, document }: Schema): SidebarM
 }
 
 export function getWebhooksSidebarGroups({ config, document }: Schema): SidebarManualGroup['items'] {
-  const baseLink = getBaseLink(config)
+  const baseLink = getBasePath(config)
   const operations = getWebhooksOperations(document)
 
   if (operations.length === 0) {

--- a/packages/starlight-openapi/libs/route.ts
+++ b/packages/starlight-openapi/libs/route.ts
@@ -1,14 +1,14 @@
 import schemas from 'virtual:starlight-openapi-schemas'
 
 import { getOperationsByTag, getWebhooksOperations, type PathItemOperation } from './operation'
-import { getBaseLink, stripLeadingAndTrailingSlashes } from './path'
+import { getBasePath, stripLeadingAndTrailingSlashes } from './path'
 import type { Schema } from './schema'
 
 export function getSchemaStaticPaths(): StarlighOpenAPIRoute[] {
   return Object.values(schemas).flatMap((schema) => [
     {
       params: {
-        openAPISlug: stripLeadingAndTrailingSlashes(getBaseLink(schema.config)),
+        openAPISlug: stripLeadingAndTrailingSlashes(getBasePath(schema.config)),
       },
       props: {
         schema,
@@ -21,7 +21,7 @@ export function getSchemaStaticPaths(): StarlighOpenAPIRoute[] {
 }
 
 function getPathItemStaticPaths(schema: Schema): StarlighOpenAPIRoute[] {
-  const baseLink = getBaseLink(schema.config)
+  const baseLink = getBasePath(schema.config)
   const operations = getOperationsByTag(schema.document)
 
   return [...operations.entries()].flatMap(([, operations]) =>
@@ -39,7 +39,7 @@ function getPathItemStaticPaths(schema: Schema): StarlighOpenAPIRoute[] {
 }
 
 function getWebhooksStaticPaths(schema: Schema): StarlighOpenAPIRoute[] {
-  const baseLink = getBaseLink(schema.config)
+  const baseLink = getBasePath(schema.config)
   const operations = getWebhooksOperations(schema.document)
 
   return operations.map((operation) => ({

--- a/packages/starlight-openapi/libs/schema.ts
+++ b/packages/starlight-openapi/libs/schema.ts
@@ -1,7 +1,7 @@
 import { z } from 'astro/zod'
 import type { OpenAPI } from 'openapi-types'
 
-import { getBaseLink, stripLeadingAndTrailingSlashes } from './path'
+import { getBasePath, stripLeadingAndTrailingSlashes } from './path'
 import { getPathItemSidebarGroups, getWebhooksSidebarGroups } from './pathItem'
 import { makeSidebarGroup, makeSidebarLink, type SidebarManualGroup } from './starlight'
 
@@ -32,7 +32,7 @@ export function getSchemaSidebarGroups(schema: Schema): SidebarManualGroup {
   return makeSidebarGroup(
     config.label ?? document.info.title,
     [
-      makeSidebarLink('Overview', getBaseLink(config)),
+      makeSidebarLink('Overview', getBasePath(config)),
       ...getPathItemSidebarGroups(schema),
       ...getWebhooksSidebarGroups(schema),
     ],


### PR DESCRIPTION
 Closes https://github.com/HiDeoo/starlight-openapi/issues/54


<!---
Thanks for submitting a pull request 😄 !
Please provide as much details as possible, including screenshots or sample code if necessary.
-->
Thank you for maintaining and contributing to this amazing repository. It has been incredibly helpful for our project, and I truly appreciate the effort that goes into its development.

Please note that English is not my first language, so I apologize if any part of this pull request or issue report seems unnatural or unclear. I hope the provided details are sufficient, and I’m happy to clarify or adjust anything if needed.

**Describe the pull request**

This pull request fixes an issue where the base configuration in Astro was not applied to the security component. Specifically, links generated by the security component did not include the base prefix, leading to incorrect or broken links.

The changes ensure that the base configuration is consistently applied to all generated links.

**Why**

These changes are necessary to ensure that:

1. The base configuration in Astro is respected across all components, including security.
2. Links generated by the security component work correctly, even when the base configuration is specified.
3. The application behaves as expected in environments where the base path is configured (e.g., hosted in subdirectories).
Without this fix, links generated by the security component fail in environments where a base configuration is required.

**How**

The changes were implemented as follows:

1. Introduced logic to handle import.meta.env.BASE_URL, trimming any trailing slash to avoid double slashes when concatenating paths.
2. Updated the href attribute in the security component to prepend BASE_URL to the existing link path.
3. Ensured the changes are backward-compatible by handling cases where BASE_URL is undefined or empty.
The key code modification:

```javascript
const baseURL = (import.meta.env.BASE_URL || '').replace(/\/$/, ''); // Trim trailing slash or fallback to empty
Updated the link generation logic:
```

```javascript
<a href={`${baseURL}${getBaseLink(schema.config)}#${slug(scheme)}`}>{scheme}</a>
```
This ensures that links are always prefixed correctly, regardless of the presence or value of BASE_URL.


<!-- Feel free to add additional comments. -->
issue: https://github.com/HiDeoo/starlight-openapi/issues/54