### PR TITLE
feat: support numeric tags

### DIFF
--- a/.changeset/cold-hairs-shave.md
+++ b/.changeset/cold-hairs-shave.md
@@ -1,0 +1,5 @@
+---
+'starlight-openapi': patch
+---
+
+Fixes an issue preventing numeric enum values from being rendered.

--- a/.changeset/moody-colts-repeat.md
+++ b/.changeset/moody-colts-repeat.md
@@ -1,5 +1,0 @@
----
-'starlight-openapi': patch
----
-
-Adds support for numeric tags.

--- a/.changeset/moody-colts-repeat.md
+++ b/.changeset/moody-colts-repeat.md
@@ -1,0 +1,5 @@
+---
+'starlight-openapi': patch
+---
+
+Adds support for numeric tags.

--- a/packages/starlight-openapi/components/Tags.astro
+++ b/packages/starlight-openapi/components/Tags.astro
@@ -8,7 +8,7 @@ interface Props {
 
 const { label, tags: allTags } = Astro.props
 
-const tags = allTags.filter((tag): tag is string => typeof tag === 'string')
+const tags = allTags.filter((tag): tag is string | number => typeof tag === 'string' || typeof tag === 'number')
 ---
 
 {
@@ -16,7 +16,7 @@ const tags = allTags.filter((tag): tag is string => typeof tag === 'string')
     <div class="tags">
       {label && <>{label}</>}
       {tags.map((tag) => {
-        if (tag.length === 0) {
+        if (typeof tag === 'string' && tag.length === 0) {
           return <Tag>&quot;&quot;</Tag>
         }
 

--- a/packages/starlight-openapi/tests/parameter.test.ts
+++ b/packages/starlight-openapi/tests/parameter.test.ts
@@ -21,7 +21,7 @@ test('overrides path item level parameters', async ({ docPage }) => {
 
   await expect(docPage.getParameters('query').getByText('The path item level limit parameter')).not.toBeVisible()
   await expect(
-    docPage.getParameters('query').getByText('How many animals to return at one time (max 100)'),
+    docPage.getParameters('query').getByText('How many animals to return at one time (max 50)'),
   ).toBeVisible()
 })
 
@@ -32,7 +32,8 @@ test('displays basic parameters', async ({ docPage }) => {
 
   await expect(limitParameter.getByText('required')).not.toBeVisible()
   await expect(limitParameter.getByText('deprecated')).toBeVisible()
-  await expect(limitParameter.getByText('How many animals to return at one time (max 100)')).toBeVisible()
+  await expect(limitParameter.getByText('How many animals to return at one time (max 50)')).toBeVisible()
+  await expect(limitParameter.getByText('Allowed values: 10 20 50')).toBeVisible()
 
   const tagsParameter = docPage.getParameter('query', 'tags')
 

--- a/schemas/v3.0/animals.yaml
+++ b/schemas/v3.0/animals.yaml
@@ -55,13 +55,17 @@ paths:
       parameters:
         - name: limit
           in: query
-          description: How many animals to return at one time (max 100)
+          description: How many animals to return at one time (max 50)
           deprecated: true
           schema:
             type: integer
             maximum: 50
             format: int32
             nullable: true
+            enum:
+              - 10
+              - 20
+              - 50
         - name: offset
           in: header
           description: The number of animals to skip before starting to collect the result set


### PR DESCRIPTION
**Describe the pull request**

this pr updates the `Tags.astro` component to support numeric tags in addition to string tags.

**Why**

this change allows for the correct display of numeric openapi `enum` values or other lists of allowed numeric values when they are represented as tags. for example, status codes (e.g., `200`, `404`) or other numeric enumerated values can now be rendered.

**How**

the `allTags` filter within `Tags.astro` was modified to include elements where `typeof tag === 'number'`.

i'm open to feedback and suggestions on this change.